### PR TITLE
add bash script, xslt, and missing ttl file (for root resource)

### DIFF
--- a/linkeddatahub/docs/decorate-html.xsl
+++ b/linkeddatahub/docs/decorate-html.xsl
@@ -9,46 +9,7 @@
 		<xsl:copy>
 			<xsl:apply-templates/>
 			<!-- add CSS -->
-			<style type="text/css" xsl:expand-text="false">
-				body {
-					color: #04286E;
-					font-family: "Rubik", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
-					display: grid;
-					grid-auto-columns: max-content;
-				}
-				body > header {
-					grid-row: 1;
-					grid-column: 1 / 2;
-				}
-				nav.outline {
-					background-color: #fff;
-					background-clip: border-box;
-					border: 1px solid rgba(0,0,0,.125);
-					margin: 0.5em;
-					width: 20em;
-					grid-row: 2;
-					grid-column: 1;
-				}
-				main {
-					grid-row: 2;
-					grid-column: 2;
-				}
-				nav.outline ul li {
-					margin-top: 0.2em;
-					margin-bottom: 0.3em;
-				}
-				nav.outline ul {
-					font-size: small;
-					padding-left: 2em;
-					margin-top: 0.1em;
-					margin-bottom: 0.3em;
-					list-style-type: none;
-				}
-				p.lead {
-					font-size: larger;
-					font-style: italic;
-				}
-			</style>
+			<link rel="stylesheet" type="text/css" href="/docs.css"/>
 		</xsl:copy>
 	</xsl:template>
 	
@@ -58,19 +19,27 @@
 	
 	<xsl:template match="body">
 		<xsl:param name="outline" tunnel="yes"/><!-- an unordered list of items containing hyperlinks or nested unordered lists -->
+		<xsl:param name="children" tunnel="yes"/><!-- an unordered list of items containing hyperlinks to subordinate resources -->
 		<xsl:copy>
-			<header><h1>LinkedDataHub</h1></header>
+			<header><p>LinkedDataHub</p></header>
 			<nav class="outline">
 				<xsl:copy-of select="$outline"/>
 			</nav>
 			<main>
 				<header>
-					<h2><xsl:value-of select="/html/head/title"/></h2>
+					<h1><xsl:value-of select="/html/head/title"/></h1>
+					<!-- include any "lead" paragraphs from the boxy here -->
+					<xsl:copy-of select="child::div/p[@class='lead']"/>
+					<nav class="children">
+						<xsl:sequence select="$children"/>
+					</nav>
 				</header>
-				<!-- insert the <body> content -->
+				<!-- copy the remaining content -->
 				<xsl:apply-templates/>
 			</main>
 		</xsl:copy>
 	</xsl:template>
+	
+	<xsl:template match="p[@class='lead']"/><!-- filter these from the main content as they're included specifically in the main header instead -->
 	
 </xsl:stylesheet>

--- a/linkeddatahub/docs/decorate-html.xsl
+++ b/linkeddatahub/docs/decorate-html.xsl
@@ -1,0 +1,76 @@
+<!-- This stylesheet is responsible for decorating a plain XHTML page generated from the Turtle data files -->
+<!-- Those pages don't include any boilerplate text or navigation; this stylesheet can add them -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" 
+	xmlns:convert="tag:conaltuohy.com,2021:convert-ttl-to-html" xmlns="http://www.w3.org/1999/xhtml" xpath-default-namespace="http://www.w3.org/1999/xhtml"
+	exclude-result-prefixes="convert">
+	<xsl:mode on-no-match="shallow-copy"/>
+	
+	<xsl:template match="head">
+		<xsl:copy>
+			<xsl:apply-templates/>
+			<!-- add CSS -->
+			<style type="text/css" xsl:expand-text="false">
+				body {
+					color: #04286E;
+					font-family: "Rubik", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+					display: grid;
+					grid-auto-columns: max-content;
+				}
+				body > header {
+					grid-row: 1;
+					grid-column: 1 / 2;
+				}
+				nav.outline {
+					background-color: #fff;
+					background-clip: border-box;
+					border: 1px solid rgba(0,0,0,.125);
+					margin: 0.5em;
+					width: 20em;
+					grid-row: 2;
+					grid-column: 1;
+				}
+				main {
+					grid-row: 2;
+					grid-column: 2;
+				}
+				nav.outline ul li {
+					margin-top: 0.2em;
+					margin-bottom: 0.3em;
+				}
+				nav.outline ul {
+					font-size: small;
+					padding-left: 2em;
+					margin-top: 0.1em;
+					margin-bottom: 0.3em;
+					list-style-type: none;
+				}
+				p.lead {
+					font-size: larger;
+					font-style: italic;
+				}
+			</style>
+		</xsl:copy>
+	</xsl:template>
+	
+	<xsl:template match="title/text()">
+		<xsl:value-of select=" 'LinkedDataHub - ' || . "/>
+	</xsl:template>
+	
+	<xsl:template match="body">
+		<xsl:param name="outline" tunnel="yes"/><!-- an unordered list of items containing hyperlinks or nested unordered lists -->
+		<xsl:copy>
+			<header><h1>LinkedDataHub</h1></header>
+			<nav class="outline">
+				<xsl:copy-of select="$outline"/>
+			</nav>
+			<main>
+				<header>
+					<h2><xsl:value-of select="/html/head/title"/></h2>
+				</header>
+				<!-- insert the <body> content -->
+				<xsl:apply-templates/>
+			</main>
+		</xsl:copy>
+	</xsl:template>
+	
+</xsl:stylesheet>

--- a/linkeddatahub/docs/docs.css
+++ b/linkeddatahub/docs/docs.css
@@ -1,0 +1,72 @@
+body {
+	color: #04286E;
+	font-family: "Rubik", "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+	display: grid;
+	grid-auto-columns: max-content;
+}
+/* page banner */ 
+body > header {
+	grid-row: 1;
+	grid-column: 1 / 2;
+}
+body > header > p {
+	font-weight: bold;
+	font-size: large;
+}
+/* table of contents of the entire website */
+nav.outline {
+	background-color: #fff;
+	background-clip: border-box;
+	border: 1px solid rgba(0,0,0,.125);
+	margin: 0.5rem;
+	padding: 1.5rem;
+	width: 14rem;
+	grid-row: 2;
+	grid-column: 1;
+}
+nav.outline > p {
+	margin-top: 0rem;
+	font-size: large;
+	font-weight: bold;
+}
+nav.outline ul li p {
+	margin-top: 0.2rem;
+	margin-bottom: 0.3rem;
+}
+nav.outline ul {
+	margin-left: 0;
+	font-size: small;
+	margin-top: 0.1rem;
+	margin-bottom: 0.3rem;
+	list-style-type: none;
+	padding-left: 1.5rem;
+}
+nav.outline > ul {
+	padding-left: 0rem;
+}
+/* the container of the list of child pages of the current page */
+nav.children {
+	background-color: #fff;
+	border: 1px solid rgba(0,0,0,.125);
+	margin: 0.5rem;
+}
+nav.children ul {
+	list-style-type: none;
+	padding: 0rem;
+	margin: 1rem;
+}
+nav.children p {
+	margin-top: 0.2rem;
+	margin-bottom: 0.3rem;
+}
+/* page content */
+main {
+	padding: 1rem;
+	grid-row: 2;
+	grid-column: 2;
+}
+/* the introductory paragraph */
+p.lead {
+	font-size: larger;
+	font-style: italic;
+}

--- a/linkeddatahub/docs/linkeddatahub.ttl
+++ b/linkeddatahub/docs/linkeddatahub.ttl
@@ -1,0 +1,14 @@
+@prefix ns:     <ns#> .
+@prefix nsdd:   <ns/domain/default#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy/domain#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+@prefix sioc:   <http://rdfs.org/sioc/ns#> .
+
+<> a nsdd:Container ;
+    dh:select <queries/default/select-children/#this> ;
+    dct:title "LinkedDataHub" ;
+    dct:description "The Knowledge Graph management system" ;
+    sioc:content """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">LinkedDataHub is open source software you can use to manage data, create visualizations and build apps on RDF Knowledge Graphs</p></div>"""^^rdf:XMLLiteral .

--- a/linkeddatahub/docs/trix-to-html.xsl
+++ b/linkeddatahub/docs/trix-to-html.xsl
@@ -1,0 +1,144 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0" 
+	xmlns:trix="http://www.w3.org/2004/03/trix/trix-1/" xmlns:convert="tag:conaltuohy.com,2021:convert-ttl-to-html" xmlns="http://www.w3.org/1999/xhtml"
+	exclude-result-prefixes="convert trix">
+	
+	<xsl:output method="text"/>
+	
+	<xsl:import href="decorate-html.xsl"/>
+	
+	<!-- folder where the XHTML files are written --> 
+	<xsl:param name="output-folder" select=" 'html' "/>
+	
+	<!-- generate an HTML filename for each resource -->
+	<xsl:function name="convert:filename-for-resource">
+		<xsl:param name="resource"/>
+		<xsl:sequence select="replace($resource, '^file://(/.*/?)$', '$1index.html')"/>
+	</xsl:function>
+	
+	<xsl:function name="convert:relativize-uri-segments">
+		<xsl:param name="uri-segments"/>
+		<xsl:param name="base-uri-segments"/>
+		<xsl:choose>
+			<xsl:when test="head($uri-segments) = head($base-uri-segments)">
+				<xsl:sequence select="convert:relativize-uri-segments(tail($uri-segments), tail($base-uri-segments))"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<!-- the base uri segments must be converted to '..' and followed by the uri segments -->
+				<xsl:sequence select="
+					(
+						for $base-segment in tail($base-uri-segments) return '..',
+						$uri-segments
+					)
+				"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:function>
+	
+	<xsl:function name="convert:relativize-uri">
+		<!-- returns a version of a root-relative $uri which is made relative to the root-relative $base-uri -->
+		<!-- e.g. convert:relativize-uri('/foo/bar/baz/index.html', '/foo/bar/quux/bong/index.html') = '../../baz/index.html' -->
+		<!-- if the $uri does not begin with '/' then it is returned unchanged -->
+		<xsl:param name="uri"/>
+		<xsl:param name="base-uri"/>
+		<xsl:choose>
+			<xsl:when test="starts-with($uri, '/')">
+				<xsl:variable name="uri-segments" select="tail(tokenize($uri, '/'))"/>
+				<xsl:variable name="base-uri-segments" select="tail(tokenize($base-uri, '/'))"/>
+				<xsl:variable name="relative-uri-segments" select="convert:relativize-uri-segments($uri-segments, $base-uri-segments)"/>
+				<xsl:sequence select="string-join($relative-uri-segments, '/')"/>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:sequence select="$uri"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:function>
+		
+	<!-- render a graph as an HTML page -->
+	<xsl:template match="trix:graph">
+		<xsl:variable name="graph" select="."/>
+		<!-- the resource identifier is taken to be the subject of the first triple -->
+		<xsl:variable name="resource" select="string(trix:triple[1]/trix:uri[1])"/>
+		<xsl:variable name="output-file" select="$output-folder || convert:filename-for-resource($resource)"/>
+		<xsl:message select="$output-file"/>
+		<!-- 
+		properties used:
+			http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+			http://rdfs.org/sioc/ns#has_parent
+			https://www.w3.org/ns/ldt/document-hierarchy/domain#select
+			http://purl.org/dc/terms/title
+			http://purl.org/dc/terms/description
+			http://rdfs.org/sioc/ns#content
+			http://rdfs.org/sioc/ns#has_container
+			http://www.w3.org/2000/01/rdf-schema#seeAlso
+		-->
+		<xsl:result-document href="{$output-file}" method="xhtml" html-version="5">
+			<xsl:variable name="plain-html">
+				<html>
+					<head>
+						<title><xsl:value-of select="convert:get-object($graph, $resource, 'http://purl.org/dc/terms/title')"/></title>
+						<meta name="description" content="{convert:get-object(., $resource, 'http://purl.org/dc/terms/description')}"/>
+						<xsl:for-each select="
+							(
+								convert:get-object($graph, $resource, 'http://rdfs.org/sioc/ns#has_container'), 
+								convert:get-object($graph, $resource, 'http://rdfs.org/sioc/ns#has_parent')
+							)
+						">
+							<link rel="up" href="{convert:relativize-uri(convert:filename-for-resource(.), convert:filename-for-resource($resource))}"/>
+						</xsl:for-each>
+						<xsl:for-each select="convert:get-object($graph, $resource, 'http://www.w3.org/2000/01/rdf-schema#seeAlso')">
+							<xsl:variable name="see-also-resource" select="."/>
+							<link rel="http://www.w3.org/2000/01/rdf-schema#seeAlso" href="{$see-also-resource}" title="{convert:get-object($graph, $see-also-resource, 'http://purl.org/dc/terms/title')}"/>
+						</xsl:for-each>
+					</head>
+					<body>
+						<xsl:copy-of select="convert:get-object(., $resource, 'http://rdfs.org/sioc/ns#content')/*"/>
+					</body>
+				</html>
+			</xsl:variable>
+			<xsl:variable name="outline">
+				<xsl:call-template name="generate-outline">
+					<xsl:with-param name="base-uri" select="convert:filename-for-resource($resource)"/>
+					<xsl:with-param name="parent-resource" select=" 'file:///' "/>
+				</xsl:call-template>
+			</xsl:variable>
+			<!-- delegate to the decorate-html.xsl stylesheet to decorate the plain html document, including formatting of the outline of the documentation corpus -->
+			<xsl:apply-templates select="$plain-html">
+				<xsl:with-param name="outline" select="$outline" tunnel="yes"/>
+			</xsl:apply-templates>
+		</xsl:result-document>
+	</xsl:template>
+	<!-- retrieve object from a triple with a given subject and predicate -->
+	<xsl:function name="convert:get-object">
+		<xsl:param name="graph"/>
+		<xsl:param name="subject"/>
+		<xsl:param name="predicate"/>
+		<xsl:sequence select="$graph/trix:triple[*[1]=$subject][*[2]=$predicate]/*[3]"/>
+	</xsl:function>
+	
+	<xsl:template name="generate-outline">
+		<xsl:param name="parent-resource"/>
+		<xsl:param name="base-uri"/>
+		<xsl:variable name="resource-statements" select="/trix:trix/trix:graph/trix:triple[*[1]=$parent-resource]"/>
+		<a href="{convert:relativize-uri(convert:filename-for-resource($parent-resource), $base-uri)}" title="{$resource-statements[*[2]='http://purl.org/dc/terms/description'][1]/*[3]}">
+			<xsl:value-of select="$resource-statements[*[2]='http://purl.org/dc/terms/title'][1]/*[3]"/>
+		</a>
+		<xsl:where-populated>
+			<ul>
+				<!-- generate an outline for each resource which has this resource as its parent or container -->
+				<xsl:for-each select="
+					/trix:trix/trix:graph/trix:triple
+						[*[3]=$parent-resource]
+						[*[2]=('http://rdfs.org/sioc/ns#has_container', 'http://rdfs.org/sioc/ns#has_parent')]
+						/*[1]
+				">
+					<li>
+						<xsl:call-template name="generate-outline">
+							<xsl:with-param name="parent-resource" select="."/>
+							<xsl:with-param name="base-uri" select="$base-uri"/>
+						</xsl:call-template>
+					</li>
+				</xsl:for-each>
+			</ul>
+		</xsl:where-populated>
+	</xsl:template>
+</xsl:stylesheet>

--- a/linkeddatahub/docs/ttl-to-html.sh
+++ b/linkeddatahub/docs/ttl-to-html.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# absolute path to output folder
+#OUTPUT_FOLDER=$PWD/html
+OUTPUT_FOLDER=/var/www/html
+# find all the turtle files and use Jena riot to convert them to TriX format, merging them into a single trix file
+# (sed is used to trim the <trix> root element from the individual files) 
+
+# The individual Turtle files are in actual fact not distinct graphs with their own base URI; they are all fragments of a single graph,
+# as is evidenced by the way that some of them have a #has_parent relationships referring to that same graph as <>, so for this 
+# conversion, we maintain the correct references by explicitly assigning all the graphs the same base URI <file:///>.
+# The script uses sed to trim the first and last lines from each TriX file (the start and end tags for the root trix element), 
+# so as to be able to concatenate the trix data into a single file. 
+echo '<trix xmlns="http://www.w3.org/2004/03/trix/trix-1/">' > docs.trix
+find . -name "*.ttl" -exec sh -c "riot --output=trix --base='file:///' {} | sed '1d;\$d' >> docs.trix"  \;
+echo '</trix>' >> docs.trix
+mkdir -p "$OUTPUT_FOLDER"
+# convert the TriX data file to a set of XHTML pages
+docker run --rm -v "$PWD":"/docs" -v "$OUTPUT_FOLDER":"/output" atomgraph/saxon -s:/docs/docs.trix -xsl:/docs/trix-to-html.xsl output-folder="/output"
+# delete the temporary trix file
+rm docs.trix


### PR DESCRIPTION
The bash script  `ttl-to-html.sh` defines a variable `OUTPUT_FOLDER` where the HTML files are to be written. For my purposes I've set it to `/var/www/html` which is the document root for my Apache 2 web server.

The bash script then uses Jena riot to convert the turtle files to trix xml, so they can be transformed via XSLT. I noticed that the turtle documents used `<>` to refer to the root resource of the entire website, not to the turtle document itself. So in the conversion I have set all the turtle files to have the same URI (`file:///`) in order that the merged data forms a coherent graph. The trix files are crudely merged into a single graph by removing the first and last line containing the root element start and end tags, and concatenating them.

Then the script uses the Saxon docker image to execute the `ttl-to-html.xsl` transformation. I mount the PWD and the OUTPUT_FOLDER as two distinct volumes. The `ttl-to-html.xsl` stylesheet expects an `output-folder` parameter, and I've set that to match the mount location of the OUTPUT_FOLDER in the docker image (`/output`).

The `ttl-to-html.xsl` stylesheet generates a full XHTML page, containing the HTML literal content from the turtle files, and populates the HTML `head` with the other metadata from the turtle files (title, description, parent topic link, seeAlso link). 

The `ttl-to-html.xsl` stylesheet imports the `decorate-html.xsl` stylesheet, and delegates to it to format the plain XHTML pages into full pages. It also generates an outline menu (nested HTML lists, containing hyperlinks) for the entire site and passes that to `decorate-html.xsl` as a tunnel parameter, so it can be inserted into the full page. I've done a basic `decorate-html.xsl` but I expect you will want to change this significantly.

In order to generate pages that could be served as static files, in response to URIs ending in `/`, I converted the resources to `index.html` files inside a directory of the appropriate name, e.g. the resource `user-guide/import-data/import-csv-data/` produces the file `user-guide/import-data/import-csv-data/index.html`. The XHTML literals in the turtle files also include hyperlinks pointing to URIs ending in `/`, so they will continue to match.

I noted that (apart from being the parent of the top-level topics) the root of the website was not really represented in the RDF graph; there was no actual content for the `<>` resource. So I added the small turtle file `linkeddatahub.ttl` to represent the home page of the documentation, which ends up as the `index.html` page of the site.

