### PR TITLE
Migrate from type-based templates to property-based inverse views in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Packages provide ontology imports and custom XSLT templates for rendering specif
 ### Structure
 
 Each package consists of:
-- **`ns.ttl`** - Ontology with vocabulary imports (`owl:imports`) and template blocks (`ldh:template`)
+- **`ns.ttl`** - Ontology with vocabulary imports (`owl:imports`) and property views (`ldh:view` / `ldh:inverseView`)
 - **`layout.xsl`** - XSLT stylesheet with custom rendering templates using system modes
 
 ### Installation
@@ -135,7 +135,7 @@ Installation integrates the package by:
 
 - **Declarative only** - RDF + XSLT, no Java code
 - **Installation-time composition** - Pre-composed before loading, no runtime overhead
-- **Template blocks** (`ldh:template`) - SPARQL-based views attached to RDF types
+- **Property views** (`ldh:view` / `ldh:inverseView`) - SPARQL-based views attached to properties
 - **XSLT overrides** - Custom rendering using system modes (`bs2:*`, `xhtml:*`, etc.)
 
 [Read the full packages documentation →](packages/README.md)

--- a/demo/northwind-traders/admin/model/ns.ttl
+++ b/demo/northwind-traders/admin/model/ns.ttl
@@ -130,6 +130,7 @@ schema:sponsor a owl:ObjectProperty ;
 
 schema:orderedItem a owl:ObjectProperty ;
     rdfs:label "Ordered item" ;
+    rdfs:range schema:Product ;
     rdfs:isDefinedBy : .
 
 schema:name a owl:DatatypeProperty ;
@@ -253,11 +254,11 @@ schema:location a owl:ObjectProperty ;
     owl:maxCardinality 1 ;
     rdfs:isDefinedBy : .
 
-# Person
+# broker
 
 # orders handled by this employee
 
-schema:Person ldh:template :OrdersHandledByEmployee .
+schema:broker ldh:inverseView :OrdersHandledByEmployee .
 
 :OrdersHandledByEmployee a ldh:View ;
     dct:title "Orders handled by this employee" ;
@@ -278,11 +279,11 @@ ORDER BY DESC(?order)
 """ ;
     rdfs:isDefinedBy : .
 
-# Corporation
+# customer
 
 # orders from this customer
 
-schema:Corporation ldh:template :OrdersFromCustomer .
+schema:customer ldh:inverseView :OrdersFromCustomer .
 
 :OrdersFromCustomer a ldh:View ;
     dct:title "Orders from this customer" ;
@@ -303,9 +304,11 @@ ORDER BY DESC(?order)
 """ ;
     rdfs:isDefinedBy : .
 
+# provider
+
 # products supplied by this supplier
 
-schema:Corporation ldh:template :ProductsFromSupplier .
+schema:provider ldh:inverseView :ProductsFromSupplier .
 
 :ProductsFromSupplier a ldh:View ;
     dct:title "Products supplied by this supplier" ;
@@ -326,11 +329,11 @@ ORDER BY ?product
 """ ;
     rdfs:isDefinedBy : .
 
-# Place
+# containedInPlace
 
 # cities in this region
 
-schema:Place ldh:template :CitiesInRegion .
+schema:containedInPlace ldh:inverseView :CitiesInRegion .
 
 :CitiesInRegion a ldh:View ;
     dct:title "Cities in this region" ;
@@ -351,11 +354,11 @@ ORDER BY ?city
 """ ;
     rdfs:isDefinedBy : .
 
-# Product
+# orderedItem
 
 # orders containing this product
 
-schema:Product ldh:template :OrdersContainingProduct .
+schema:orderedItem ldh:inverseView :OrdersContainingProduct .
 
 :OrdersContainingProduct a ldh:View ;
     dct:title "Orders containing this product" ;


### PR DESCRIPTION
…Northwind ontology

Replace `ldh:template` on RDF types (schema:Person, schema:Corporation, schema:Place, schema:Product) with `ldh:inverseView` on the relevant properties (schema:broker, schema:customer, schema:provider, schema:containedInPlace, schema:orderedItem). Update README to reflect the new ldh:view / ldh:inverseView terminology. Remove empty categories container.ttl.