### PR TITLE
Fix non-canonical XMLLiteral in dataspace.ttl

### DIFF
--- a/docs/reference/dataspace.ttl
+++ b/docs/reference/dataspace.ttl
@@ -67,7 +67,7 @@
             <h3 id="admin-apps">Administration</h3>
             <p>Every administration application is related to one <a href="#end-user-apps">end-user application</a>. It cannot exist standalone.</p>
             <p>The base URI of an administration application is the base URI of its end-user application with the <code>admin.</code> subdomain
-                prefixed to the host (e.g. <samp>https://example.com/</samp> &#8594; <samp>https://admin.example.com/</samp>). Because the admin application lives on
+                prefixed to the host (e.g. <samp>https://example.com/</samp> → <samp>https://admin.example.com/</samp>). Because the admin application lives on
                 its own subdomain (origin), it no longer occupies a path within the end-user application.</p>
             <div class="alert alert-info">
                 <p>Since LinkedDataHub 5.1.0 the administration application is served on the <code>admin.</code> subdomain rather than under an


### PR DESCRIPTION
Replaces the numeric character reference `&#8594;` with the literal `→` in the `dataspace.ttl` documentation, so the `rdf:XMLLiteral` lexical form is canonical XML.

Jena 6 (the LinkedDataHub build) rejects entity references in XMLLiteral lexical forms with `not valid for datatype XSD XMLLiteral`; the convention in these docs is to use literal Unicode characters (e.g. `↔`, `—`). Follow-up to the documentation updates merged in #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)