### PR TITLE
Fix documentation inaccuracies against LinkedDataHub 5.6.0

### DIFF
--- a/docs/reference/administration/ontologies.ttl
+++ b/docs/reference/administration/ontologies.ttl
@@ -58,7 +58,7 @@
                         <td><code>lapp:</code></td>
                     </tr>
                     <tr>
-                        <td><a href="https://w3id.org/atomgraph/linkeddatahub/acl" id="lacl-ont" target="_blank"><code>https://w3id.org/atomgraph/linkeddatahub/acl#</code></a></td>
+                        <td><a href="https://w3id.org/atomgraph/linkeddatahub/admin/acl" id="lacl-ont" target="_blank"><code>https://w3id.org/atomgraph/linkeddatahub/admin/acl#</code></a></td>
                         <td>Access control</td>
                         <td><code>lacl:</code></td>
                     </tr>

--- a/docs/reference/command-line-interface.ttl
+++ b/docs/reference/command-line-interface.ttl
@@ -231,7 +231,7 @@ Options:
                 </tr>
                 <tr>
                     <td>Add <code>CONSTRUCT</code> query</td>
-                    <td><samp>admin/ontologies/add-construct.sh</samp></td>
+                    <td><samp>admin/ontologies/add-constructor.sh</samp></td>
                 </tr>
                 <tr>
                     <td>Create <a href="../administration/ontologies/#ontologies">ontology</a></td>

--- a/docs/reference/configuration.ttl
+++ b/docs/reference/configuration.ttl
@@ -141,6 +141,20 @@
             </dl>
         </div>
         <div>
+            <h3 id="http-client">HTTP client timeouts</h3>
+            <p>Timeouts and connection lifetimes for LinkedDataHub's pooled HTTP clients, used for the <a href="../http-api/#ld-proxy">Linked Data proxy</a> and for accessing SPARQL services. All values are in milliseconds and are passed as <samp>CATALINA_OPTS</samp> system properties.</p>
+            <dl>
+                <dt><samp>CLIENT_SOCKET_TIMEOUT</samp></dt>
+                <dd>Socket (read) timeout — how long to wait for data on an established connection. By default <samp>120000</samp>.</dd>
+                <dt><samp>CLIENT_CONNECT_TIMEOUT</samp></dt>
+                <dd>Connection timeout — how long to wait to establish a connection. By default <samp>10000</samp>.</dd>
+                <dt><samp>CLIENT_CONNECTION_TIME_TO_LIVE</samp></dt>
+                <dd>Maximum lifetime of a pooled connection before it is closed. By default <samp>300000</samp>.</dd>
+                <dt><samp>CLIENT_VALIDATE_AFTER_INACTIVITY</samp></dt>
+                <dd>Idle time after which a pooled connection is validated before reuse. By default <samp>10000</samp>.</dd>
+            </dl>
+        </div>
+        <div>
             <h3 id="varnish">Varnish</h3>
             <dl>
                 <dt><samp>VARNISH_FRONTEND_BACKEND_PORT</samp></dt>

--- a/docs/reference/data-model/resources/views.ttl
+++ b/docs/reference/data-model/resources/views.ttl
@@ -22,7 +22,7 @@
     <p>To render paginated lists of resources, legacy applications would normally have a dedicated API endpoint that
     supports pagination, ordering etc. In LinkedDataHub, views achieve the same functionality by simply building the
     SPARQL query string on the client-side. Therefore views can be seen as client-side "containers".</p>
-    <p>Views can be rendered in multiple layout modes: properties, list, grid, table, map, chart etc. They also show
+    <p>Views can be rendered in multiple layout modes: properties, list, grid, table, map, chart, and graph. They also show
     the total number of results and allow result ordering by property.</p>
     <div>
         <h2 id="layout-modes">Layout modes</h2>

--- a/docs/reference/user-interface.ttl
+++ b/docs/reference/user-interface.ttl
@@ -17,7 +17,7 @@
     <p>The UI layout <a href="../../user-guide/change-layout/" target="_blank">can be customized</a> and extended using <a href="../../reference/stylesheets/" target="_blank">stylesheets</a>.</p>
     <div class="alert alert-info">
         <p><em>Note that user interface features are subject to <a href="../administration/acl/">access control</a>. For example,
-            the search box will not be visible if the user is not authorized to access the search container.</em></p>
+            actions such as creating or editing documents are only available to users with the corresponding write access.</em></p>
     </div>
     <p>
         <img alt="User interface" src="../../uploads/df0b96b07dc6730536cb11d169ed34dfb25ea403"></img>
@@ -28,7 +28,8 @@
             <img alt="Navigation bar" src="../../uploads/ec8cb7afb9cf360c34e859f97646642eb0331518"></img>
         </p>
         <p>The application title or logo in the top-left always links to the root container of the current application.</p>
-        <p><dfn>Search box</dfn> lets users search for resources within the current application that have the specified keyword in their titles, descriptions etc. Results are shown in a dropdown list.</p>
+        <p>The <dfn>address bar</dfn> in the middle accepts the URI of a resource to navigate to. Entering an external <code>http://</code> or <code>https://</code> URL loads it through the <a href="../http-api/#linked-data-proxy">Linked Data proxy</a> so that it can be browsed within LinkedDataHub.</p>
+        <p>On the right, dropdown menus provide access to the list of applications and to your user account.</p>
         <div class="alert alert-info">
             <p><em>Due to current web browser limitations, it is not possible to logout using client certificate authentication.
               As a workaround, you can close the browser, and click <span class="btn">Cancel</span> when asked to select a
@@ -54,38 +55,36 @@
         </div>
     </div>
     <div>
-        <h2 id="document-tree">Document tree</h2>
-        <p>The left sidebar provides two complementary ways to navigate your data: by document hierarchy and by class.</p>
+        <h2 id="document-tree">Left sidebar</h2>
+        <p>The left sidebar is the main way to navigate your data. At the top, the <dfn>search box</dfn> finds resources within the current application that have the specified keyword in their titles, descriptions etc.; results are shown in a dropdown list. Below the search box, the sidebar offers complementary ways to browse the dataspace — by document hierarchy, by class, and through a few other data-driven views.</p>
         <h3 id="document-hierarchy">Document hierarchy navigation</h3>
         <p>Document tree shows the document hierarchy of the dataspace. By clicking on a container, it expands to show its children.</p>
         <p>In a desktop layout mode, the document tree folds out when the mouse is moved to the left edge of the screen. In a responsive layout, it is always shown.</p>
         <h3 id="class-navigation">Class-based navigation</h3>
-        <p>In addition to browsing by document hierarchy, you can navigate your data by class. The class tree displays all classes defined in your
-        application's ontology, organized by their <code>rdfs:subClassOf</code> relationships. Clicking on a class in the tree shows all instances
-        of that class in your dataspace.</p>
+        <p>In addition to browsing by document hierarchy, you can navigate your data by class. The <dfn>Classes</dfn> list shows the classes (<code>rdf:type</code> values) that actually occur in the dataspace, each labelled with the number of its instances and ordered with the most-used classes first. Clicking a class opens a dialog listing all instances of that class across the dataspace.</p>
         <p>Class-based navigation is particularly useful when:</p>
         <ul>
             <li>You want to see all instances of a particular type across your entire dataspace</li>
             <li>You need to browse data organized by domain concepts rather than container structure</li>
-            <li>You're working with data that has rich class hierarchies</li>
         </ul>
-        <p>The class tree respects your <a href="../administration/acl/">access control</a> settings — you'll only see classes and instances you're authorized to access.</p>
-        <h3 id="system-containers">System containers</h3>
-        <p>The document tree also provides shortcuts to <a href="../data-model/documents/#hierarchy">system containers</a>:</p>
+        <p>Because the list is derived from the data itself, it reflects whatever types are present — you do not need to define an ontology or class hierarchy. It also respects your <a href="../administration/acl/">access control</a> settings: you only see classes and instances you are authorized to access.</p>
+        <h3 id="other-views">Other views</h3>
+        <p>Below the classes, the sidebar provides a couple of additional data-driven views of the dataspace:</p>
         <dl>
-          <dt>Latest</dt>
-          <dd>A container with the latest resources in the application's dataset by creation/modification date</dd>
-          <dt>Files</dt>
-          <dd>A container for <a href="../../user-guide/upload-file/">file uploads</a></dd>
-          <dt>Imports</dt>
-          <dd>A container for <a href="../imports/">data imports</a></dd>
-          <dt>Queries</dt>
-          <dd>A container for end-user SPARQL queries (including <a href="../imports/csv/#vocabulary-conversion">vocabulary
-              mappings</a>)</dd>
           <dt>Geo</dt>
-          <dd>A container with all resources in the application's dataset that have geographic coordinates</dd>
-          <dt>Charts</dt>
-          <dd>A container with charts that visualize SPARQL query results</dd>
+          <dd>Opens a dialog listing all resources in the dataspace that have geographic coordinates.</dd>
+          <dt>Latest</dt>
+          <dd>Opens a dialog listing the most recently created resources in the dataspace, newest first.</dd>
+        </dl>
+    </div>
+    <div>
+        <h2 id="right-nav">Right sidebar</h2>
+        <p>A right sidebar appears alongside the main view to show navigation into and out of the current data:</p>
+        <dl>
+            <dt>Backlinks</dt>
+            <dd>In <a href="#layout-modes">properties mode</a>, lists resources that link <em>to</em> a resource in the current document — that is, resources that have a property whose value is the current resource. This complements the outgoing properties shown in the main view.</dd>
+            <dt>Related results</dt>
+            <dd>For <a href="../data-model/resources/views/#parallax">view</a> result sets, <dfn>parallax</dfn> navigation lets you jump from the current results to a related set by following a selected property (for example, from a set of products to the companies that supply them). It works together with the view's faceted search.</dd>
         </dl>
     </div>
     <div>

--- a/docs/user-guide/import-data/import-csv-data.ttl
+++ b/docs/user-guide/import-data/import-csv-data.ttl
@@ -64,8 +64,8 @@
                                 <dd>Query title</dd>
                             </dl>
                         </li>
-                        <li>Once all the fields have been filled in click <span class="btn btn-primary btn-save">Save</span>. You can find this saved under
-                                <dfn>Queries</dfn> container in <a href="../../../reference/user-interface/#left-nav">left navigation</a>.</li>
+                        <li>Once all the fields have been filled in click <span class="btn btn-primary btn-save">Save</span>. You can find it saved in the
+                                <dfn>Queries</dfn> container, which you can open from the <a href="../../../reference/user-interface/#document-tree">document tree</a> in the left sidebar.</li>
                         <li>Click on the <span class="btn btn-primary create-action">Create <span class="caret"></span></span> dropdown button at the top left-hand corner and select <dfn>CSV Import</dfn>.
                                 This will open a new form.</li>
                         <li>Fill out <dfn>Item</dfn> fields</li>

--- a/docs/user-guide/import-data/import-rdf-data.ttl
+++ b/docs/user-guide/import-data/import-rdf-data.ttl
@@ -135,8 +135,8 @@
                                     <dd>Query title</dd>
                                 </dl>
                             </li>
-                            <li>Once all the fields have been filled in click <span class="btn btn-primary btn-save">Save</span>. You can find this saved under
-                                    <dfn>Queries</dfn> container in <a href="../../../reference/user-interface/#left-nav">left navigation</a>.</li>
+                            <li>Once all the fields have been filled in click <span class="btn btn-primary btn-save">Save</span>. You can find it saved in the
+                                    <dfn>Queries</dfn> container, which you can open from the <a href="../../../reference/user-interface/#document-tree">document tree</a> in the left sidebar.</li>
                             <li>Click on the <span class="btn btn-primary create-action">Create <span class="caret"></span></span> dropdown button at the top left-hand corner and select <dfn>RDF Import</dfn>.
                                     This will open a new form.</li>
                             <li>Fill out <dfn>Item</dfn> fields</li>

--- a/docs/user-guide/navigate-data.ttl
+++ b/docs/user-guide/navigate-data.ttl
@@ -24,26 +24,22 @@
         </p>
     </div>
     <div>
-        <h2 id="class-tree">Class tree</h2>
-        <p>In addition to navigating by document hierarchy, LinkedDataHub provides class-based navigation through the class tree widget.
-        The class tree displays all classes from your application's ontology, organized by their inheritance relationships (<code>rdfs:subClassOf</code>).</p>
+        <h2 id="class-tree">Class-based navigation</h2>
+        <p>In addition to navigating by document hierarchy, LinkedDataHub lets you navigate by class. The <dfn>Classes</dfn> list in the left sidebar shows the classes (<code>rdf:type</code> values) that occur in your data, each labelled with the number of its instances and ordered with the most-used classes first.</p>
         <h3>Using class-based navigation</h3>
         <ol>
-            <li>Open the left sidebar (slide mouse to left edge on desktop, or it's always visible on responsive layouts)</li>
-            <li>Switch to the class tree view (if not already showing)</li>
-            <li>Browse the class hierarchy — classes are organized by their subclass relationships</li>
-            <li>Click on any class to view all instances of that class in your dataspace</li>
-            <li>Expand parent classes to see their subclasses</li>
+            <li>Open the left sidebar (slide the mouse to the left edge on desktop, or it is always visible on responsive layouts)</li>
+            <li>Find the <dfn>Classes</dfn> list</li>
+            <li>Click on any class to open a dialog listing all instances of that class in your dataspace</li>
         </ol>
         <h3>When to use class navigation</h3>
         <p>Class-based navigation is most useful when:</p>
         <ul>
             <li><strong>Finding all instances of a type:</strong> Quickly locate all resources of a particular class, regardless of where they're stored in the document hierarchy</li>
             <li><strong>Exploring domain concepts:</strong> Browse your data organized by business concepts (e.g., all Customers, all Orders) rather than by container structure</li>
-            <li><strong>Working with rich ontologies:</strong> Navigate through complex class hierarchies to understand and access your data model</li>
             <li><strong>Cross-container queries:</strong> View instances that span multiple containers in a single unified view</li>
         </ul>
-        <p>The class tree respects your access control settings — you'll only see classes you're authorized to view, and only instances you have permission to access.</p>
+        <p>The classes list is derived from the data itself, so it reflects whatever types are present — no ontology needs to be defined. It respects your access control settings — you'll only see classes and instances you're authorized to access.</p>
     </div>
     <div>
         <h2 id="backlinks">Backlinks</h2>

--- a/docs/user-guide/search-data.ttl
+++ b/docs/user-guide/search-data.ttl
@@ -13,10 +13,10 @@
     <p class="lead">Search for resources using text keywords</p>
     <div>
         <h2 id="text-search">Text search</h2>
-        <p>You can lookup resources by typing a phrase (it does not have to be complete, start with a few letters) into the input in the <a href="../../reference/user-interface/#nav-bar">navigation bar</a>.</p>
+        <p>You can lookup resources by typing a phrase (it does not have to be complete, start with a few letters) into the <a href="../../reference/user-interface/#document-tree">search box</a> at the top of the left sidebar.</p>
         <p>A dropdown list will appear if there are any matches. Use up/down keys or mouse click to select one of the results, and you will be redirected to its document.</p>
         <p>The matching is done by looking for substrings using SPARQL <code>regex()</code> in common literal properties such as <code>dct:title</code>, <code>rdfs:label</code>, <code>foaf:name</code> etc. You can find the exact query in <samp>Queries / Select labelled</samp>.</p>
-        <p>The same widget is used for autocomplete inputs in the <a href="../../reference/user-interface/#create-edit">create/edit forms</a>.</p>
+        <p>The same widget is used for autocomplete inputs in the <a href="../../reference/user-interface/#action-bar">create/edit forms</a>.</p>
         <p>
             <img alt="SPARQL endpoint" src="../../uploads/8c4383351477a5405a9883d23d9255670b9396f7"></img>
         </p>


### PR DESCRIPTION
Corrects documentation inaccuracies found by auditing the `docs/` sources against the **LinkedDataHub 5.6.0** release code (verified against `master`). All edited files pass `trig --validate`.

## User interface reference (`reference/user-interface.ttl`)
- Removed the stale **System containers** section (Latest/Files/Imports/Queries/Geo/Charts shortcuts) — these no longer exist. Replaced with an accurate **Other views** section (only **Geo** and **Latest** survive, as sidebar buttons).
- Corrected the **class-based navigation** description: it's a flat, data-driven list of the `rdf:type` values present in the data (with instance counts), opening a dialog of instances — not an `rdfs:subClassOf` "class tree".
- Moved the **keyword search box** into the left sidebar (where it actually renders); the navbar section now describes the **URI address bar** and right-side menus.
- Added a **Right sidebar** section documenting **backlinks** and **related results / parallax** (previously undocumented).

## Reference
- `command-line-interface`: `admin/ontologies/add-construct.sh` → **`add-constructor.sh`** (matches `bin/`).
- `administration/ontologies`: ACL ontology namespace `…/linkeddatahub/acl#` → **`…/linkeddatahub/admin/acl#`** (per `LACL.java` / `lacl.ttl`).
- `data-model/resources/views`: layout-modes list now includes the **Graph** mode (`ac:GraphMode`, added in 5.4.0).
- `configuration`: documented the four released **`CLIENT_*` HTTP client timeout** env vars (defaults 120000 / 10000 / 300000 / 10000 ms).

## User guide
- `navigate-data` & `search-data`: class navigation corrected as above; keyword search box is in the left sidebar, not the navigation bar.
- `import-csv-data` & `import-rdf-data`: the **Queries** container is now reached via the **document tree** (its left-nav shortcut was removed; the container itself still exists).
- Fixed dangling internal anchors `#left-nav`, `#right-nav`, `#create-edit`.

## Not changed (verified accurate)
HTTP API methods/status codes & PATCH semantics, Linked Data proxy, ACL modes/vocab, ontology/package model, CSV/RDF imports, content-block type constraint, class/property URIs, triplestores, dataspace/dataset, get-started/setup. Unreleased env vars (`WEBID_CACHE_EXPIRATION`/`JWKS_CACHE_EXPIRATION`) are intentionally left undocumented for 5.6.0.

## Note
`docs/html/**` build artifacts are **not** included — regenerate with `make ttl-to-html` before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
