### PR TITLE
Add app-building tutorial section to docs

### DIFF
--- a/docs/about.ttl
+++ b/docs/about.ttl
@@ -25,7 +25,7 @@
             <li>authentication using WebID and OpenID Connect</li>
             <li><a href="../reference/administration/acl/" target="_blank">access control</a> using WAC authorizations</li>
         </ul>
-        <p class="lead">Checkout the user guide on <a href="../user-guide/build-apps/">application building</a>.</p>
+        <p class="lead">Follow the <a href="../tutorial/">tutorial</a> to build your first app, then see the user guide on <a href="../user-guide/build-apps/">application building</a> for the extension layers.</p>
     </div>
     <div>
         <h2 id="kms">Federated knowledge management and collaboration system</h2>

--- a/docs/get-started.ttl
+++ b/docs/get-started.ttl
@@ -14,6 +14,7 @@
     <p class="lead">All the basics of LinkedDataHub. From installation to customizing the model and user interface.</p>
     <p>This guide will show how a LinkedDataHub application can be used to manage domain-specific RDF classes and instances. As an example, we will use <a href="https://www.w3.org/TR/skos-primer/" target="_blank">SKOS</a> concepts and concept schemes.</p>
     <p>Note that most management actions can also be performed using the <a href="../reference/command-line-interface/" target="_blank">CLI (Command Line Interface)</a>. Where applicable, the UI and CLI instructions are shown side by side. The <a href="https://github.com/AtomGraph/LinkedDataHub-Apps/tree/master/demo/unesco-thesaurus" target="_blank">UNESCO Thesaurus demo app</a> demonstrates how SKOS vocabularies can be managed in LinkedDataHub.</p>
+    <p class="lead">New to LinkedDataHub? The <a href="../tutorial/" target="_blank">tutorial</a> builds a complete application, from an empty dataspace to a published app.</p>
     <div>
         <h2 id="setup">Setup</h2>
         <p>Setup is only required if you plan to run your own instance of LinkedDataHub. It consists of few steps, which involve creating a configuration file and running a

--- a/docs/tutorial.ttl
+++ b/docs/tutorial.ttl
@@ -1,0 +1,37 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Container ;
+    dct:title "Tutorial" ;
+    dct:description "Build your first Knowledge Graph application, from an empty dataspace to a published app" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Build your first Knowledge Graph application, from an empty dataspace to a published app</p>
+    <p>This tutorial rebuilds the <a href="https://github.com/AtomGraph/LinkedDataHub-Apps/tree/master/demo/northwind-traders" target="_blank">Northwind Traders demo application</a>: the iconic sample
+        database, reborn as an RDF Knowledge Graph. Every stage ends with a result you can see in the browser. Most steps are shown two ways: point-and-click in the user interface, and as
+        <a href="../reference/command-line-interface/" target="_blank">CLI commands</a> that you can script, version and replay.</p>
+    <p>Before you start you need a running LinkedDataHub instance and the owner's WebID certificate. The <a href="../get-started/" target="_blank">Get started</a> section covers both. The command line
+        examples assume the <code>bin/</code> scripts are on your <code>PATH</code> and use these shell variables throughout:</p>
+    <pre>base="https://localhost:4443/"
+cert_pem_file="ssl/owner/cert.pem"
+cert_password="..."</pre>
+    <div>
+        <h2 id="stages">Stages</h2>
+        <ol>
+            <li><a href="hello-dataspace/">Hello dataspace</a> — give your app an identity and a landing page</li>
+            <li><a href="structure/">Structure</a> — lay out the document hierarchy</li>
+            <li><a href="model/">Model</a> — define the vocabulary that describes your domain</li>
+            <li><a href="data/">Data</a> — import CSV data using SPARQL mappings</li>
+            <li><a href="media/">Media</a> — upload files and link them to resources</li>
+            <li><a href="insight/">Insight</a> — turn SPARQL queries into charts and views</li>
+            <li><a href="composition/">Composition</a> — assemble the landing page from content blocks</li>
+            <li><a href="publish/">Publish</a> — grant public access and ship it</li>
+            <li><a href="app-as-repository/">App as a repository</a> — make the app reproducible</li>
+            <li><a href="beyond-low-code/">Beyond low-code</a> — where to go when data alone is not enough</li>
+        </ol>
+    </div>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/app-as-repository.ttl
+++ b/docs/tutorial/app-as-repository.ttl
@@ -12,8 +12,7 @@
     rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
     <p class="lead">Make the app reproducible: a git repository that installs into any instance</p>
     <p>Every stage so far produced files — document descriptions, mapping queries, CSV data, media. Kept in a repository with a small install script, they <em>are</em> the application: versionable,
-        diffable, reviewable, and replayable into any LinkedDataHub instance. This is the layout the <a href="https://github.com/AtomGraph/LinkedDataHub-Apps/tree/master/demo/northwind-traders"
-        target="_blank">Northwind Traders repository</a> uses:</p>
+        diffable, reviewable, and replayable into any LinkedDataHub instance. This is the layout the <a href="https://github.com/AtomGraph/LinkedDataHub-Apps/tree/master/demo/northwind-traders" target="_blank">Northwind Traders repository</a> uses:</p>
     <pre>northwind-traders/
 ├── root.ttl              # one .ttl per document...
 ├── categories.ttl

--- a/docs/tutorial/app-as-repository.ttl
+++ b/docs/tutorial/app-as-repository.ttl
@@ -1,0 +1,51 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "App as a repository" ;
+    dct:description "Make the app reproducible: a git repository that installs into any instance" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Make the app reproducible: a git repository that installs into any instance</p>
+    <p>Every stage so far produced files — document descriptions, mapping queries, CSV data, media. Kept in a repository with a small install script, they <em>are</em> the application: versionable,
+        diffable, reviewable, and replayable into any LinkedDataHub instance. This is the layout the <a href="https://github.com/AtomGraph/LinkedDataHub-Apps/tree/master/demo/northwind-traders"
+        target="_blank">Northwind Traders repository</a> uses:</p>
+    <pre>northwind-traders/
+├── root.ttl              # one .ttl per document...
+├── categories.ttl
+├── categories/           # ...and a folder for the files it imports
+│   ├── categories.csv
+│   ├── categories.rq
+│   └── *.gif
+├── admin/model/
+│   ├── ns.ttl            # the namespace ontology
+│   ├── patch-ontology.ru # resets it before re-import
+│   └── import-ns.sh
+├── imports.csv           # the CSV import manifest
+├── install.sh            # replays everything against a base URI
+├── update-folder.sh
+├── .ldhignore            # files that are not documents
+└── Makefile</pre>
+    <div>
+        <h2 id="convention">The convention</h2>
+        <p>The document URL is derived from the file path: <samp>categories.ttl</samp> installs to <samp>${base}categories/</samp>, <samp>root.ttl</samp> to <samp>${base}</samp> itself.
+            <samp>update-folder.sh</samp> walks the tree applying that rule — resolving each file's relative URIs against its document URL and <code>PUT</code>ting the result — and skips anything
+            matched by <samp>.ldhignore</samp>.</p>
+    </div>
+    <div>
+        <h2 id="idempotency">Idempotency</h2>
+        <p>Re-running the install converges instead of duplicating: <code>PUT</code> replaces each document's description outright, and the one place that appends rather than replaces — the
+            namespace ontology — is first reset by <samp>patch-ontology.ru</samp>, a SPARQL update that clears the previously imported terms.</p>
+    </div>
+    <div>
+        <h2 id="install">Installing</h2>
+        <pre>make install</pre>
+        <p>prompts for the base URI, certificate and password, then runs <samp>install.sh</samp>: make public, import the ontology, replay the documents, upload the files, run the CSV imports. The
+            entire tutorial, replayed in one command — against localhost today, against production tomorrow.</p>
+    </div>
+    <p class="lead">Next: <a href="../beyond-low-code/">Beyond low-code</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/beyond-low-code.ttl
+++ b/docs/tutorial/beyond-low-code.ttl
@@ -1,0 +1,26 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Beyond low-code" ;
+    dct:description "Where to go when data alone is not enough" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Where to go when data alone is not enough</p>
+    <p>Everything in this tutorial was done with data: documents, queries and authorizations, applied over HTTP. That is the ceiling of the low-code approach — and there is a door in it. Each layer
+        of LinkedDataHub can be extended without forking it:</p>
+    <ul>
+        <li><strong>Layout</strong> — write an XSLT stylesheet that imports the system one and overrides only the templates you need. Start with the
+            <a href="../../user-guide/change-layout/" target="_blank">Change layout</a> guide and the <a href="../../reference/stylesheets/" target="_blank">stylesheets reference</a>.</li>
+        <li><strong>Docker and Java</strong> — mount files into the stock image, build your own image on top of it, or add JAX-RS endpoints via a WAR overlay. The
+            <a href="../../user-guide/build-apps/" target="_blank">Build apps</a> guide covers each layer with working build files.</li>
+        <li><strong>More examples</strong> — the <a href="https://github.com/AtomGraph/LinkedDataHub-Apps" target="_blank">LinkedDataHub-Apps repository</a> holds the complete Northwind Traders
+            source alongside further demo apps and installable packages.</li>
+    </ul>
+    <p>If you get stuck or build something worth showing, open a thread on <a href="https://github.com/AtomGraph/LinkedDataHub/discussions" target="_blank">GitHub Discussions</a>.</p>
+    <p class="lead">Back to the <a href="../">Tutorial</a> overview</p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/composition.ttl
+++ b/docs/tutorial/composition.ttl
@@ -1,0 +1,39 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Composition" ;
+    dct:description "Assemble the landing page from content blocks" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Assemble the landing page from content blocks</p>
+    <p>Everything the app can show is now in place — text, data, charts, views. The landing page is their composition: an ordered sequence of
+        <a href="../../reference/data-model/blocks/" target="_blank">content blocks</a> on the root document. Two block types exist: <code>ldh:XHTML</code> holds authored markup, and
+        <code>ldh:Object</code> embeds any other resource — a chart, a view, a document. Anything that is not markup gets wrapped in an object block.</p>
+    <p>The demo's finished root document interleaves them into an executive dashboard:</p>
+    <pre>&lt;&gt; a def:Root ;
+    dct:title "Northwind Traders" ;
+    rdf:_1 &lt;#page-header&gt; ;          # XHTML   — title and pitch
+    rdf:_2 &lt;#overview-intro&gt; ;       # XHTML   — dashboard intro
+    rdf:_3 &lt;#sales-trend-block&gt; ;    # Object  — monthly sales line chart
+    rdf:_4 &lt;#revenue-by-country-block&gt; ; # Object — geo chart
+    rdf:_5 &lt;#top-selling-products&gt; ; # Object  — product ranking
+    rdf:_6 &lt;#top-manager-header&gt; ;   # XHTML   — section heading
+    rdf:_7 &lt;#top-manager&gt; ;          # Object  — employee of the quarter
+    rdf:_8 &lt;#navigation-prompt&gt; ;    # XHTML   — where to go next
+    rdf:_9 &lt;#select-children&gt; .      # Object  — children view</pre>
+    <p>The narrative rhythm — prose, then evidence, then prose — is an editorial choice, and it is made entirely in data: reordering the page is renumbering <code>rdf:_N</code>. In the browser the
+        same composition is drag-and-drop in edit mode; from the command line it is the <samp>root.ttl</samp> from the <a href="../hello-dataspace/">first stage</a> grown to its final form, applied
+        with the same <code>PUT</code>.</p>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>The homepage is the finished application: branded header, live charts over the imported graph, and navigation into the containers — every pixel of it a rendering of one document's
+            description.</p>
+        <!-- screenshot: the finished Northwind landing page -->
+    </div>
+    <p class="lead">Next: <a href="../publish/">Publish</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/data.ttl
+++ b/docs/tutorial/data.ttl
@@ -49,7 +49,7 @@ WHERE
     </ul>
     <div>
         <h2 id="browser">In the browser</h2>
-        <p>Create the import from the UI — upload the CSV file, pick the mapping query and the target container — following the <a href="../../user-guide/import-data/" target="_blank">Import data</a>
+        <p>Create the import from the UI — upload the CSV file, pick the mapping query and the target container — following the <a href="../../user-guide/import-data/import-csv-data/" target="_blank">Import CSV data</a>
             guide.</p>
     </div>
     <div>

--- a/docs/tutorial/data.ttl
+++ b/docs/tutorial/data.ttl
@@ -1,0 +1,75 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Data" ;
+    dct:description "Import CSV data using SPARQL mappings" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Import CSV data using SPARQL mappings</p>
+    <p>Northwind's data ships as plain CSV files. LinkedDataHub <a href="../../reference/imports/csv/" target="_blank">imports CSV</a> by running a SPARQL <code>CONSTRUCT</code> mapping over each
+        row: the row's cells are bound as properties of a row resource, and the query builds the RDF you want from them. The mapping for categories, <samp>categories.rq</samp>:</p>
+    <pre>PREFIX foaf:       &lt;http://xmlns.com/foaf/0.1/&gt;
+PREFIX dct:        &lt;http://purl.org/dc/terms/&gt;
+PREFIX schema:     &lt;https://schema.org/&gt;
+
+CONSTRUCT
+{
+    GRAPH ?graph
+    {
+        ?graph dct:title ?categoryName ;
+            foaf:primaryTopic ?category .
+
+        ?category a schema:ProductGroup ;
+            dct:title ?categoryName ;
+            schema:name ?categoryName ;
+            schema:identifier ?categoryID ;
+            schema:description ?description .
+    }
+}
+WHERE
+{
+    ?category_row &lt;#categoryID&gt; ?categoryID ;
+        &lt;#description&gt; ?description ;
+        &lt;#categoryName&gt; ?categoryName .
+
+    BIND(uri(concat(str($base), "categories/")) AS ?container)
+    BIND(uri(concat(str(?container), encode_for_uri(?categoryID), "/")) AS ?graph)
+    BIND(uri(concat(str(?graph), "#this")) AS ?category)
+}</pre>
+    <p>The three <code>BIND</code>s carry the whole document model of the import:</p>
+    <ul>
+        <li><code>?container</code> — the target container from the <a href="../structure/">Structure</a> stage, resolved against <code>$base</code></li>
+        <li><code>?graph</code> — one document (named graph) per row, minted inside the container from the row's identifier</li>
+        <li><code>?category</code> — the document's topic: the document is <em>about</em> the category, so the category is a <samp>#this</samp> fragment of it</li>
+    </ul>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>Create the import from the UI — upload the CSV file, pick the mapping query and the target container — following the <a href="../../user-guide/import-data/" target="_blank">Import data</a>
+            guide.</p>
+    </div>
+    <div>
+        <h2 id="cli">From the command line</h2>
+        <p>Each import pairs a mapping query with a CSV file and a target container. The demo lists them in a manifest, <samp>imports.csv</samp>:</p>
+        <pre>query_filename,csv_filename,target,title
+categories/categories.rq,categories/categories.csv,categories/,Categories
+products/products.rq,products/products.csv,products/,Products
+orders/orders.rq,orders/orders.csv,orders/,Orders
+...</pre>
+        <p>and replays the manifest with a small script built on the <a href="../../reference/command-line-interface/" target="_blank">CLI</a>'s <code>create-csv-import.sh</code>:</p>
+        <pre>./import-csv.sh "$base" "$cert_pem_file" "$cert_password" "$PWD/imports.csv"</pre>
+        <p>Imports run asynchronously — each one is itself a document that records its status.</p>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>The Categories container lists eight category documents. Open one: the category renders with its name, description and identifier, typed as a product group — with the labels coming from
+            the <a href="../model/">Model</a> stage. Repeat the pattern for the remaining entities and the Knowledge Graph fills in, orders linking to products, products to suppliers and
+            categories.</p>
+        <!-- screenshot: the Categories container listing after the import -->
+    </div>
+    <p class="lead">Next: <a href="../media/">Media</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/hello-dataspace.ttl
+++ b/docs/tutorial/hello-dataspace.ttl
@@ -1,0 +1,69 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Hello dataspace" ;
+    dct:description "Give your app an identity: a title, a description and a landing page" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Give your app an identity: a title, a description and a landing page</p>
+    <p>In LinkedDataHub everything is a <a href="../../reference/data-model/documents/" target="_blank">document</a>, and every document is a named graph whose name is the document's URL. Your
+        dataspace starts with a single document: the <strong>root document</strong> at the base URI. It doubles as the app's homepage, so making the app yours starts with describing this one
+        document.</p>
+    <p>In this stage you give the root document a title, a description and a first <a href="../../reference/data-model/blocks/" target="_blank">content block</a> — and see the result render as your
+        homepage.</p>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>Open the base URL (e.g. <samp>https://localhost:4443/</samp>) and authenticate with the owner's WebID certificate. Switch the root document into edit mode, change the title to
+            <samp>Northwind Traders</samp>, fill in the description, and add an XHTML content block with a short welcome text. The <a href="../../user-guide/edit-content/" target="_blank">Edit
+            content</a> guide walks through the block editor in detail.</p>
+        <!-- screenshot: root document in edit mode with the title and first XHTML block -->
+    </div>
+    <div>
+        <h2 id="cli">From the command line</h2>
+        <p>The same change, expressed as data. Describe the root document in a <samp>root.ttl</samp> file:</p>
+        <pre>@prefix def:    &lt;https://w3id.org/atomgraph/linkeddatahub/default#&gt; .
+@prefix ldh:    &lt;https://w3id.org/atomgraph/linkeddatahub#&gt; .
+@prefix rdf:    &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt; .
+@prefix dct:    &lt;http://purl.org/dc/terms/&gt; .
+
+&lt;&gt; a def:Root ;
+    dct:title "Northwind Traders" ;
+    dct:description "Knowledge Graph representation of the Northwind Traders sample database" ;
+    rdf:_1 &lt;#intro&gt; .
+
+&lt;#intro&gt; a ldh:XHTML ;
+    rdf:value '''&lt;div xmlns="http://www.w3.org/1999/xhtml"&gt;
+        &lt;div class="page-header"&gt;
+            &lt;h2&gt;Northwind Traders&lt;/h2&gt;
+            &lt;p class="lead"&gt;The iconic sample database converted to an RDF Knowledge Graph&lt;/p&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;'''^^rdf:XMLLiteral .</pre>
+        <p>Then replace the root document's description with it using <code>PUT</code>. The <code>turtle</code> command resolves the relative URIs in the file against the document URL, so the same
+            file installs against any base URI:</p>
+        <pre>cat root.ttl | turtle --base="$base" | put.sh \\
+    -f "$cert_pem_file" \\
+    -p "$cert_password" \\
+    -t "application/n-triples" \\
+    "$base"</pre>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>Reload the base URL: the homepage now carries your title and welcome text. You have not touched a template, a controller or a database schema — you replaced the description of one
+            document, and the UI is a rendering of that description.</p>
+        <!-- screenshot: the branded homepage after the update -->
+    </div>
+    <div>
+        <h2 id="how-this-works">How this works</h2>
+        <ul>
+            <li><a href="../../reference/data-model/documents/" target="_blank">Documents</a> — the document hierarchy and how documents map to named graphs</li>
+            <li><a href="../../reference/data-model/blocks/" target="_blank">Content blocks</a> — how <code>rdf:_1</code>, <code>rdf:_2</code>, … sequence a document's content</li>
+            <li><a href="../../reference/http-api/" target="_blank">HTTP API</a> — the <code>PUT</code> semantics behind <code>put.sh</code></li>
+        </ul>
+    </div>
+    <p class="lead">Next: <a href="../structure/">Structure</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/insight.ttl
+++ b/docs/tutorial/insight.ttl
@@ -1,0 +1,73 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Insight" ;
+    dct:description "Turn SPARQL queries into charts and views" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Turn SPARQL queries into charts and views</p>
+    <p>With the graph populated, analysis is a query away — and in LinkedDataHub, queries, <a href="../../reference/data-model/resources/charts/" target="_blank">charts</a> and
+        <a href="../../reference/data-model/resources/views/" target="_blank">views</a> are resources like everything else. A chart is three resources chained together: a
+        <code>sp:Select</code> query holding the SPARQL text, a <code>ldh:ResultSetChart</code> describing how to plot its results, and a <code>ldh:Object</code> block placing it on a document.</p>
+    <div>
+        <h2 id="chart">A revenue chart</h2>
+        <p>On the Categories container, revenue per category — the query joins order items to products to categories across their documents:</p>
+        <pre>&lt;#category-revenue-query&gt; a sp:Select ;
+    dct:title "Category revenue" ;
+    sp:text '''PREFIX schema: &lt;https://schema.org/&gt;
+
+SELECT ?categoryName (SUM(?sale) AS ?revenue)
+WHERE {
+    GRAPH ?orderGraph {
+        ?order schema:orderedItem ?orderItem .
+        ?orderItem schema:orderedItem ?product ;
+                   schema:orderQuantity ?quantity ;
+                   schema:price ?price .
+        BIND(?quantity * ?price AS ?sale)
+    }
+    GRAPH ?productGraph {
+        ?product schema:category ?category .
+    }
+    GRAPH ?categoryGraph {
+        ?category schema:name ?categoryName .
+    }
+}
+GROUP BY ?category ?categoryName
+ORDER BY DESC(?revenue)''' .
+
+&lt;#category-revenue&gt; a ldh:ResultSetChart ;
+    dct:title "Revenue by category" ;
+    spin:query &lt;#category-revenue-query&gt; ;
+    ldh:chartType &lt;https://w3id.org/atomgraph/client#BarChart&gt; ;
+    ldh:categoryVarName "categoryName" ;
+    ldh:seriesVarName "revenue" .
+
+&lt;#category-revenue-block&gt; a ldh:Object ;
+    rdf:value &lt;#category-revenue&gt; .</pre>
+        <p>Add <code>&lt;#category-revenue-block&gt;</code> to the container's block sequence (<code>rdf:_2</code> after the intro block) and <code>PUT</code> the document as before.</p>
+    </div>
+    <div>
+        <h2 id="view">A view</h2>
+        <p>Views render query results as document listings instead of plots — the container's own children listing is one. A grid of all categories:</p>
+        <pre>&lt;#select-categories-view&gt; a ldh:View ;
+    spin:query &lt;#select-categories-query&gt; ;
+    ac:mode &lt;https://w3id.org/atomgraph/client#GridMode&gt; .</pre>
+    </div>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>The same resources can be created interactively: save a query from the <a href="../../user-guide/query-data/" target="_blank">query editor</a>, then add a chart block that references
+            it.</p>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>The Categories container is a small dashboard: a revenue bar chart, a products-per-category chart, and a grid of the categories themselves — all live views over the graph, recomputed on
+            each request.</p>
+        <!-- screenshot: the Categories container with charts and grid view -->
+    </div>
+    <p class="lead">Next: <a href="../composition/">Composition</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/media.ttl
+++ b/docs/tutorial/media.ttl
@@ -1,0 +1,45 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Media" ;
+    dct:description "Upload files and link them to resources" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Upload files and link them to resources</p>
+    <p>Northwind comes with images: a photo per employee, an icon per category. Uploaded files are stored <strong>content-addressed</strong> — the file's URL is derived from the SHA-1 hash of its
+        content, under <samp>${base}uploads/</samp>. The same bytes always land at the same URL, which is what makes file references stable enough to bake into import mappings.</p>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>Upload a file with the file upload form as shown in the <a href="../../user-guide/upload-file/" target="_blank">Upload file</a> guide.</p>
+    </div>
+    <div>
+        <h2 id="cli">From the command line</h2>
+        <pre>add-file.sh \\
+    -b "$base" \\
+    -f "$cert_pem_file" \\
+    -p "$cert_password" \\
+    --title "Nancy Davolio" \\
+    --file "$PWD/employees/nancy.jpg" \\
+    --content-type "image/jpeg" \\
+    "$base"</pre>
+    </div>
+    <div>
+        <h2 id="linking">Linking files to resources</h2>
+        <p>A file becomes part of the graph the moment something points at it. The category mapping from the <a href="../data/">Data</a> stage does exactly that — the CSV carries each image's hash,
+            and the mapping mints the upload URL from it:</p>
+        <pre>?category foaf:depiction ?picture .
+...
+BIND(uri(concat(str($base), "uploads/", encode_for_uri(?pictureHash))) AS ?picture)</pre>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>Category and employee documents now render with their images — <code>foaf:depiction</code> is picked up by the default layout, no template work required.</p>
+        <!-- screenshot: an employee document with the photo rendered -->
+    </div>
+    <p class="lead">Next: <a href="../insight/">Insight</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/model.ttl
+++ b/docs/tutorial/model.ttl
@@ -1,0 +1,73 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Model" ;
+    dct:description "Define the vocabulary that describes your domain" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Define the vocabulary that describes your domain</p>
+    <p>Each dataspace has a <strong>namespace ontology</strong> where you define the classes and properties of your domain. It lives in the <em>admin</em> application, which shares your base URI with
+        an <samp>admin.</samp> subdomain prefix: for the end-user app at <samp>https://localhost:4443/</samp>, the ontology document is
+        <samp>https://admin.localhost:4443/ontologies/namespace/</samp>.</p>
+    <p>Northwind reuses <a href="https://schema.org" target="_blank">Schema.org</a> terms rather than inventing its own, so "modeling" here means declaring which classes the app works with and how
+        they should be labeled:</p>
+    <pre>@prefix :	    &lt;#&gt; .
+@prefix rdfs:	&lt;http://www.w3.org/2000/01/rdf-schema#&gt; .
+@prefix owl:    &lt;http://www.w3.org/2002/07/owl#&gt; .
+@prefix schema: &lt;https://schema.org/&gt; .
+
+: a owl:Ontology .
+
+schema:ProductGroup a owl:Class ;
+    rdfs:label "Product group" ;
+    rdfs:isDefinedBy : .
+
+schema:Product a owl:Class ;
+    rdfs:label "Product" ;
+    rdfs:isDefinedBy : .
+
+schema:Order a owl:Class ;
+    rdfs:label "Order" ;
+    rdfs:isDefinedBy : .</pre>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>Open the admin application and edit the namespace ontology document directly, or follow the <a href="../../user-guide/change-model/" target="_blank">Change model</a> guide, which also
+            shows how to add SPIN constructors to classes — the templates that drive "create instance" forms in the UI.</p>
+    </div>
+    <div>
+        <h2 id="cli">From the command line</h2>
+        <p>Append the class definitions from <samp>ns.ttl</samp> to the namespace ontology document with <code>POST</code>. The prepended <code>@base</code> makes the <code>:</code> prefix resolve to
+            <samp>${base}ns#</samp> — the terms belong to the end-user namespace even though the ontology document lives in the admin app:</p>
+        <pre>admin_base="https://admin.localhost:4443/"
+
+{ echo "@base &lt;${base}ns&gt; ."; cat ns.ttl; } | post.sh \\
+    -f "$cert_pem_file" \\
+    -p "$cert_password" \\
+    --content-type "text/turtle" \\
+    "${admin_base}ontologies/namespace/"</pre>
+        <p>Ontologies are cached in memory, so tell the application to reload it:</p>
+        <pre>clear-ontology.sh \\
+    -f "$cert_pem_file" \\
+    -p "$cert_password" \\
+    -b "$admin_base" \\
+    --ontology "${base}ns#"</pre>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>The ontology document in the admin app renders your classes with their labels. The visible payoff on the end-user side comes in the next stage: resources imported as
+            <code>schema:Product</code> or <code>schema:Order</code> arrive typed and labeled, and the model is what the UI uses to render and create them.</p>
+    </div>
+    <div>
+        <h2 id="how-this-works">How this works</h2>
+        <ul>
+            <li><a href="../../reference/administration/ontologies/" target="_blank">Ontologies</a> — namespace ontologies, imports and caching</li>
+            <li><a href="../../user-guide/change-model/" target="_blank">Change model</a> — classes, constructors and constraints from the UI</li>
+        </ul>
+    </div>
+    <p class="lead">Next: <a href="../data/">Data</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/publish.ttl
+++ b/docs/tutorial/publish.ttl
@@ -1,0 +1,33 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Publish" ;
+    dct:description "Grant public access and ship it" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Grant public access and ship it</p>
+    <p>So far only the owner's WebID certificate can see the app. Access is governed by <a href="../../reference/administration/acl/" target="_blank">ACL authorizations</a> — documents in the admin
+        app, like everything else. Publishing means creating one authorization: read access on the whole dataspace for all agents.</p>
+    <div>
+        <h2 id="cli">From the command line</h2>
+        <pre>make-public.sh -b "$base" -f "$cert_pem_file" -p "$cert_password"</pre>
+        <p>The script creates the public-read authorization in the admin application. Authorizations are data, so you can inspect the document it created — and delete it to unpublish.</p>
+    </div>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>The same authorization can be created with the access control forms in the admin application — see the <a href="../../reference/administration/acl/" target="_blank">ACL reference</a> for
+            the authorization model: who (agents, agent classes), what (documents, document classes), and which <code>acl:mode</code>.</p>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>Open the base URL in a private browser window, with no certificate: the Northwind Traders app renders, charts and all. It is now a public Linked Data dataset <em>and</em> a public web
+            application — the same URLs serve both, negotiated by content type.</p>
+        <!-- screenshot: the app in a private window, unauthenticated -->
+    </div>
+    <p class="lead">Next: <a href="../app-as-repository/">App as a repository</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/structure.ttl
+++ b/docs/tutorial/structure.ttl
@@ -1,0 +1,54 @@
+@prefix ldh:    <https://w3id.org/atomgraph/linkeddatahub#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dh:     <https://www.w3.org/ns/ldt/document-hierarchy#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+
+<> a dh:Item ;
+    dct:title "Structure" ;
+    dct:description "Lay out the document hierarchy that will hold your data" ;
+    rdf:_1 <#content> .
+
+<#content> a ldh:XHTML ;
+    rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
+    <p class="lead">Lay out the document hierarchy that will hold your data</p>
+    <p>Documents come in two kinds: <a href="../../reference/data-model/documents/containers/" target="_blank">containers</a>, which hold child documents, and
+        <a href="../../reference/data-model/documents/items/" target="_blank">items</a>. Northwind's domain gives us the container layout directly — one container per entity type:</p>
+    <pre>https://localhost:4443/
+├── categories/
+├── customers/
+├── employees/
+├── orders/
+├── products/
+├── regions/
+├── shippers/
+├── suppliers/
+└── territories/</pre>
+    <div>
+        <h2 id="browser">In the browser</h2>
+        <p>Create each container from the root document using the document creation form — see the <a href="../../user-guide/create-data/" target="_blank">Create data</a> guide.</p>
+    </div>
+    <div>
+        <h2 id="cli">From the command line</h2>
+        <p>A container is just a document whose description says it is one. <samp>categories.ttl</samp>:</p>
+        <pre>@prefix dh:     &lt;https://www.w3.org/ns/ldt/document-hierarchy#&gt; .
+@prefix dct:    &lt;http://purl.org/dc/terms/&gt; .
+
+&lt;&gt; a dh:Container ;
+    dct:title "Categories" .</pre>
+        <p><code>PUT</code> it to the container URL, the same way the root document was updated:</p>
+        <pre>cat categories.ttl | turtle --base="${base}categories/" | put.sh \\
+    -f "$cert_pem_file" \\
+    -p "$cert_password" \\
+    -t "application/n-triples" \\
+    "${base}categories/"</pre>
+        <p>Repeat for the remaining eight containers — or skip ahead to <a href="../app-as-repository/">App as a repository</a> to see how the demo derives the document URL from the filename and
+            replays a whole folder in one command.</p>
+    </div>
+    <div>
+        <h2 id="result">What you now see</h2>
+        <p>The root document now lists the containers as its children, and each container URL resolves to an (empty) listing page. The URL space of your app <em>is</em> its information
+            architecture.</p>
+        <!-- screenshot: root document children listing with the nine containers -->
+    </div>
+    <p class="lead">Next: <a href="../model/">Model</a></p>
+</div>"""^^rdf:XMLLiteral .

--- a/docs/tutorial/structure.ttl
+++ b/docs/tutorial/structure.ttl
@@ -25,7 +25,7 @@
 └── territories/</pre>
     <div>
         <h2 id="browser">In the browser</h2>
-        <p>Create each container from the root document using the document creation form — see the <a href="../../user-guide/create-data/" target="_blank">Create data</a> guide.</p>
+        <p>Create each container from the root document using the document creation form — see the <a href="../../user-guide/create-data/create-documents/" target="_blank">Create documents</a> guide.</p>
     </div>
     <div>
         <h2 id="cli">From the command line</h2>

--- a/docs/user-guide/build-apps.ttl
+++ b/docs/user-guide/build-apps.ttl
@@ -11,6 +11,7 @@
 <#content> a ldh:XHTML ;
     rdf:value """<div xmlns="http://www.w3.org/1999/xhtml">
     <p class="lead">Using LinkedDataHub as a low-code platform for Knowledge Graph applications</p>
+    <p>If you are building your first app, start with the <a href="../../tutorial/">tutorial</a> — this guide covers the layers beyond it.</p>
     <p>Every component in LinkedDataHub is data-driven and was designed with extensibility in mind. You can override behavior (e.g. Java method or XSLT template) without having to modify LinkedDataHub's
         codebase, and more importantly, without having to write the same logic from scratch.</p>
     <p>The following sections are split by component/layer and explain how to extend them when building bespoke apps.</p>


### PR DESCRIPTION
## Summary

Adds a ten-stage **Tutorial** section to the docs that rebuilds the Northwind Traders demo from an empty dataspace to a published app:

1. **Hello dataspace** — title, description and first content block on the root document
2. **Structure** — the container hierarchy
3. **Model** — namespace ontology import via the admin app
4. **Data** — CSV imports, with a walkthrough of the mapping query's document-minting `BIND` pattern
5. **Media** — content-addressed file uploads and `foaf:depiction` linking
6. **Insight** — queries, charts and views as resources
7. **Composition** — assembling the landing page from `rdf:_N` blocks
8. **Publish** — the public-read ACL authorization
9. **App as a repository** — the folder→document convention, idempotent replay, `make install`
10. **Beyond low-code** — exit ramp to the XSLT/Docker/Java extension layers

## Design notes

- Each stage ends with a visible result and a "Next:" link; the container carries a hand-curated ordered TOC instead of `ldh:ChildrenView`, since stage order is authored.
- Steps are dual-track — "In the browser" links out to the user-guide pages, "From the command line" shows commands lifted verbatim from the demo's install scripts (nothing invented).
- Screenshot slots are marked with `<!-- screenshot: ... -->` comments for later automated capture.
- All documents pass `trig --validate` and their XHTML literals pass `xmllint`; the section renders cleanly through `ttl-to-html.sh` (11 pages, picked up by nav and sitemap).

## Known follow-ups (not in this PR)

- Nav orders sections alphabetically, so Tutorial lands after Reference; moving it next to Get started needs a sort tweak in `ttl-to-html.xsl`.
- `add-file.sh` now appears both in the Media stage and `user-guide/upload-file` — a known drift surface to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
